### PR TITLE
fix homepage link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ V3.0
 [![Build Status](https://travis-ci.org/drewminns/slackdeletron.svg?branch=master)](https://travis-ci.org/drewminns/slackdeletron)
 [![MIT Licence](https://badges.frapsoft.com/os/mit/mit.svg?v=103)](https://opensource.org/licenses/mit-license.php)
 
-[slackdeletron.com](https://slackdeletron.com)
+[slackdeletron.com](https://www.slackdeletron.com)
 
 ## What the?
 


### PR DESCRIPTION
The current link leads to a very dead end.

![image](https://user-images.githubusercontent.com/11439624/45898707-b313c800-bdd2-11e8-9a7a-3f3848f61808.png)

This adds `www` in the URL so you get to the desired page.

![image](https://user-images.githubusercontent.com/11439624/45898740-c9218880-bdd2-11e8-9ac6-e4237bf8cbf5.png)